### PR TITLE
recover from morphological error

### DIFF
--- a/src/content/components/panel/component.js
+++ b/src/content/components/panel/component.js
@@ -114,6 +114,7 @@ export default class Panel extends Component {
       this.options.elements.self.classList.add(this.panelOpenedClassName)
       this.options.elements.fullWidthButton.classList.remove(this.hiddenClassName)
     }
+    return this
   }
   close () {
     if (this.isOpened) {


### PR DESCRIPTION
if lookup of morphology fails, we still want to construct a homonym object from the word the user selected and use that for definition lookups